### PR TITLE
Fix base href in docs/index.html for GitHub Pages subdirectory

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>JanusMaritzCv</title>
-  <base href="/">
+  <base href="/Janus-Maritz-CV/">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&amp;display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"/>


### PR DESCRIPTION
Built without --base-href flag, causing all assets to resolve to the root instead of /Janus-Maritz-CV/.